### PR TITLE
Log errors thrown by implementations

### DIFF
--- a/meteor-core/src/main/java/dev/pixelib/meteor/core/transport/TransportHandler.java
+++ b/meteor-core/src/main/java/dev/pixelib/meteor/core/transport/TransportHandler.java
@@ -14,9 +14,12 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class TransportHandler implements Closeable {
 
+    private final Logger logger = Logger.getLogger(TransportHandler.class.getSimpleName());
     private final RpcSerializer serializer;
     private final RpcTransport transport;
     private final IncomingInvocationTracker incomingInvocationTracker;
@@ -91,8 +94,8 @@ public class TransportHandler implements Closeable {
                 Object response = matchedImplementation.invokeOn(invocationDescriptor, invocationDescriptor.getReturnType());
                 InvocationResponse invocationResponse = new InvocationResponse(invocationDescriptor.getUniqueInvocationId(), response);
                 transport.send(Direction.METHOD_PROXY, invocationResponse.toBytes(serializer));
-            } catch (NoSuchMethodException e) {
-                e.printStackTrace();
+            } catch (Throwable e) {
+                logger.log(Level.SEVERE, "An error occurred while invoking a method", e);
             }
         });
 


### PR DESCRIPTION
It's always possible that implementations throw (unmarked) exceptions.
Currently, they just get discarded by executor thread due to them being passed through in a RunnableFuture.
I've looked into handling it through the future itself. However, it leads to some nasty casting chain, so I settled for the current solution where it just handles them through a border catch, and then logs them through a logger.

This PR does not change the behaviour of Meteor, but makes debugging of client implementations a whole lot easier.