### PR TITLE
Make redis ignore itself, if configured

### DIFF
--- a/meteor-common/src/main/java/dev/pixelib/meteor/base/interfaces/SubscriptionHandler.java
+++ b/meteor-common/src/main/java/dev/pixelib/meteor/base/interfaces/SubscriptionHandler.java
@@ -1,5 +1,6 @@
 package dev.pixelib.meteor.base.interfaces;
 
+@FunctionalInterface
 public interface SubscriptionHandler {
 
     boolean onPacket(byte[] packet) throws Exception;

--- a/meteor-core/src/main/java/dev/pixelib/meteor/core/proxy/PendingInvocation.java
+++ b/meteor-core/src/main/java/dev/pixelib/meteor/core/proxy/PendingInvocation.java
@@ -86,6 +86,7 @@ public class PendingInvocation<T> extends TimerTask {
         }
 
         isTimedOut.set(true);
+
         this.completable.completeExceptionally(
                 new InvocationTimedOutException(invocationDescriptor.getMethodName(), invocationDescriptor.getNamespace(), timeoutSeconds)
         );

--- a/meteor-core/src/main/java/dev/pixelib/meteor/core/trackers/OutgoingInvocationTracker.java
+++ b/meteor-core/src/main/java/dev/pixelib/meteor/core/trackers/OutgoingInvocationTracker.java
@@ -54,7 +54,8 @@ public class OutgoingInvocationTracker {
         // do we have a pending invocation for this invocation id?
         PendingInvocation<?> pendingInvocation = pendingInvocations.get(invocationResponse.getInvocationId());
         if (pendingInvocation == null) {
-            throw new IllegalStateException("No pending invocation found for invocation id " + invocationResponse.getInvocationId());
+            throw new IllegalStateException("No pending invocation found for invocation id " + invocationResponse.getInvocationId() + ". Data: " + invocationResponse.getResult());
+            //return;
         }
 
         pendingInvocation.complete(invocationResponse.getResult());

--- a/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/RedisPacketListener.java
+++ b/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/RedisPacketListener.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -18,10 +19,10 @@ public class RedisPacketListener extends JedisPubSub {
     private final Logger logger;
 
     private final ExecutorService jedisThreadPool = Executors.newCachedThreadPool();
-    private final Map<String, Set<SubscriptionHandler>> messageBrokers = new ConcurrentHashMap<>();
+    private final Map<String, Set<StringMessageBroker>> messageBrokers = new ConcurrentHashMap<>();
     private final Collection<String> customSubscribedChannels = ConcurrentHashMap.newKeySet();
 
-    public RedisPacketListener(SubscriptionHandler messageBroker, String startChannel, Logger logger) {
+    public RedisPacketListener(StringMessageBroker messageBroker, String startChannel, Logger logger) {
         this.logger = logger;
         registerBroker(startChannel, messageBroker);
         customSubscribedChannels.add(startChannel);
@@ -31,14 +32,14 @@ public class RedisPacketListener extends JedisPubSub {
     public void onMessage(String channel, String message) {
         messageBrokers.get(channel).forEach(subscriptionHandler -> {
             try {
-                subscriptionHandler.onPacket(Base64.getDecoder().decode(message));
+                subscriptionHandler.onRedisMessage(message);
             } catch (Exception exception) {
                 logger.log(Level.SEVERE, "Error while handling packet", exception);
             }
         });
     }
 
-    public void subscribe(String channel, SubscriptionHandler onReceive) {
+    public void subscribe(String channel, StringMessageBroker onReceive) {
         registerBroker(channel, onReceive);
 
         if (customSubscribedChannels.add(channel)) {
@@ -55,7 +56,7 @@ public class RedisPacketListener extends JedisPubSub {
         return customSubscribedChannels;
     }
 
-    private void registerBroker(String channel, SubscriptionHandler onReceive) {
+    private void registerBroker(String channel, StringMessageBroker onReceive) {
         messageBrokers.computeIfAbsent(channel, key -> ConcurrentHashMap.newKeySet()).add(onReceive);
     }
 }

--- a/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/RedisSubscriptionThread.java
+++ b/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/RedisSubscriptionThread.java
@@ -9,12 +9,13 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 public class RedisSubscriptionThread {
 
-    private final SubscriptionHandler messageBroker;
+    private final StringMessageBroker messageBroker;
     private final Logger logger;
     private final String defaultChannel;
     private final JedisPool jedisPool;
@@ -28,7 +29,7 @@ public class RedisSubscriptionThread {
         return thread;
     });
 
-    public RedisSubscriptionThread(SubscriptionHandler messageBroker, Logger logger, String channel, JedisPool jedisPool) {
+    public RedisSubscriptionThread(StringMessageBroker messageBroker, Logger logger, String channel, JedisPool jedisPool) {
         this.messageBroker = messageBroker;
         this.logger = logger;
         this.defaultChannel = channel;
@@ -69,16 +70,16 @@ public class RedisSubscriptionThread {
 
     }
 
-    public void subscribe(String channel, SubscriptionHandler onReceive) {
-        jedisPacketListener.subscribe(channel, onReceive);
-
-    }
-
     public void stop() {
         if (isStopping) return;
         isStopping = true;
         jedisPacketListener.stop();
         listenerThread.shutdownNow();
+    }
+
+    public void subscribe(String channel, StringMessageBroker onReceive) {
+        jedisPacketListener.subscribe(channel, onReceive);
+
     }
 
     private CompletableFuture<Boolean> isSubscribed() {

--- a/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/StringMessageBroker.java
+++ b/meteor-jedis/src/main/java/dev/pixelib/meteor/transport/redis/StringMessageBroker.java
@@ -1,0 +1,8 @@
+package dev.pixelib.meteor.transport.redis;
+
+@FunctionalInterface
+public interface StringMessageBroker {
+
+    boolean onRedisMessage(String message) throws Exception;
+
+}

--- a/meteor-jedis/src/test/java/dev/pixelib/meteor/transport/redis/RedisPacketListenerTest.java
+++ b/meteor-jedis/src/test/java/dev/pixelib/meteor/transport/redis/RedisPacketListenerTest.java
@@ -21,20 +21,19 @@ import static org.mockito.Mockito.*;
 class RedisPacketListenerTest {
 
     @Mock
-    SubscriptionHandler subscriptionHandler;
+    StringMessageBroker subscriptionHandler;
 
     @Test
     void onMessage_withValidChannel() throws Exception {
         String topic = "test";
-        String message = "message";
-        byte[] expected = Base64.getDecoder().decode(message);
+        String expected = "message";
 
         RedisPacketListener redisPacketListener = new RedisPacketListener(subscriptionHandler, topic, Logger.getAnonymousLogger());
 
-        redisPacketListener.onMessage(topic, message);
-        verify(subscriptionHandler, times(1)).onPacket(expected);
-        verify(subscriptionHandler).onPacket(argThat(argument -> {
-            assertArrayEquals(expected,argument);
+        redisPacketListener.onMessage(topic, expected);
+        verify(subscriptionHandler, times(1)).onRedisMessage(expected);
+        verify(subscriptionHandler).onRedisMessage(argThat(argument -> {
+            assertEquals(expected,argument);
             return true;
         }));
     }
@@ -42,24 +41,22 @@ class RedisPacketListenerTest {
     @Test
     void onMessage_throwException() throws Exception {
         String topic = "test";
-        String message = "message";
-        byte[] expected = Base64.getDecoder().decode(message);
+        String expected = "message";
 
-
-        SubscriptionHandler handler = new SubscriptionHandler() {
+        StringMessageBroker handler = new StringMessageBroker() {
             @Override
-            public boolean onPacket(byte[] packet) throws Exception {
+            public boolean onRedisMessage(String message) throws Exception {
                 throw new NullPointerException();
             }
         };
 
-        SubscriptionHandler handlerSub = spy(handler);
+        StringMessageBroker handlerSub = spy(handler);
         RedisPacketListener redisPacketListener = new RedisPacketListener(handlerSub, topic, Logger.getAnonymousLogger());
 
-        redisPacketListener.onMessage(topic, message);
-        verify(handlerSub, times(1)).onPacket(expected);
-        verify(handlerSub).onPacket(argThat(argument -> {
-            assertArrayEquals(expected,argument);
+        redisPacketListener.onMessage(topic, expected);
+        verify(handlerSub, times(1)).onRedisMessage(expected);
+        verify(handlerSub).onRedisMessage(argThat(argument -> {
+            assertEquals(expected,argument);
             return true;
         }));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
     </modules>
 
     <properties>
-        <revision>1.0.2-localbuild</revision>
+        <revision>1.0.6-localbuild</revision>
         <maven.compiler.source>17</maven.compiler.source>
         <maven.compiler.target>17</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
This PR adds functionality to the jedis module, allowing you to ignore messages published by itself.